### PR TITLE
feat: monthly time reports by user via top-level workItems API

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,7 +4,7 @@ on:
   push:
     branches: [main, dev]
   pull_request:
-    branches: [main]
+    branches: [main, dev]
 
 jobs:
   test:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,6 +1,6 @@
 # yt-mcp
 
-YouTrack MCP server. 79 tools across 19 modules.
+YouTrack MCP server. 81 tools across 20 modules.
 
 ## Build & test
 
@@ -37,6 +37,7 @@ src/yt_mcp/
     deadlines/       # deadline audit/scorecard + manager-mapping suggester (package)
     pulse.py         # team pulse (single + multi-board parallel) + insight flags
     handoffs.py      # stuck-handoff detection: cross-team transition stalls
+    time_report.py   # monthly time reports by user (top-level workItems API)
     impact.py        # dependency graph, deadline impact analysis
     dashboard.py     # scoring-based dashboards (active, blocked, team, multi-team)
     monitoring.py    # digest, at-risk, task creation checks, project health

--- a/docs/adr/032-time-reports-from-work-items.md
+++ b/docs/adr/032-time-reports-from-work-items.md
@@ -1,0 +1,61 @@
+# 032 — Time reports built on the top-level workItems API
+
+## Context
+
+PR #3 (external contribution) proposed two genuinely useful tools —
+`monthly_time_report_by_user` and `user_time_summary` — but the
+implementation aggregated time from `/api/issues` custom fields and could not
+work: the search query it built is rejected by YouTrack (400), the response
+was consumed as `{"issue": [...]}` when the endpoint returns a bare list, and
+"spent time" was read as `int(value.id)` where `value.id` is an entity id —
+so totals were always 0. Its unit tests mocked the fictional shapes and
+passed anyway. Full review with reproductions is on the PR.
+
+The feature is worth having, so this ADR re-implements it on contracts
+validated against a live instance **before** writing the code:
+
+- **Top-level `GET /api/workItems`** exists and returns a bare JSON list of
+  `IssueWorkItem`: `duration.minutes` (real integer minutes),
+  `author(login,name)`, `issue(idReadable)`, epoch-ms `date`. One paged
+  request chain covers any date range — no per-issue N+1.
+- `startDate` / `endDate` params accept `YYYY-MM-DD` and filter by
+  **work-item date**.
+- `author=<login|id>` filters server-side and 404s on unknown users — which
+  `client._handle_error` already maps to a clean `ValueError` message.
+- Multi-project filters must use the comma-list idiom (`project: A, B`);
+  OR-joined same-prefix clauses 400 (the same trap ADR-020 documents).
+
+## Decision
+
+New module `tools/time_report.py` (module #20, tools #80–81):
+
+- `monthly_time_report_by_user(instance, projects, year, month)` — sums
+  `duration.minutes` for the calendar month **grouped by work-item author**
+  (whoever logged the time), not issue assignee: assignee attribution
+  misreports any issue worked by several people, and logged time semantically
+  belongs to its logger. Filtered by work-item date, not issue `updated` (an
+  issue updated in July can carry June work). `year`/`month` default to the
+  current UTC month (0 = current).
+- `user_time_summary(user, instance, since, until, top_issues)` — one user's
+  total plus a per-issue breakdown, same attribution and date semantics;
+  `since`/`until` validated as `YYYY-MM-DD` up front.
+- Shared `_fetch_work_items`: `$top`/`$skip` pagination (page 500) with a
+  5000-item cap — and when the cap is hit the report **says so** instead of
+  silently truncating.
+- Duration formatting matches `get_work_items` in `history.py` (`2h 30m`).
+
+Both tools are read-only (no `WRITE_TOOLS` change) and full-toolset only —
+not added to `CORE_TOOLS`, consistent with ADR-026's analytics/reporting
+split.
+
+## Consequences
+
+- 79 → **81 tools**, 19 → 20 modules; registration/count tests and CLAUDE.md
+  updated. 797 tests pass.
+- Test mocks mirror the **validated** endpoint shapes (bare list,
+  `duration.minutes`), including pagination and cap-truncation paths — the
+  contract-vs-mock gap that let PR #3's bugs through cannot recur here.
+- Supersedes PR #3's implementation; the tool names and intent are kept so
+  the original idea lands (credited in the PR).
+- Also fixes the stale SDK-pin comment in `tools/__init__.py`
+  (`mcp>=1.0,<1.26` → `>=1.28.1,<2.0`, stale since ADR-030).

--- a/src/yt_mcp/tools/__init__.py
+++ b/src/yt_mcp/tools/__init__.py
@@ -1,7 +1,7 @@
 from yt_mcp.config import YouTrackConfig
 from yt_mcp.resolver import InstanceResolver
 from yt_mcp.logging import logged
-from yt_mcp.tools import issues, comments, attachments, templates, history, bulk, projects, sprints, discovery, translate, impact, users, articles, dashboard, monitoring, journey, deadlines, pulse, handoffs
+from yt_mcp.tools import issues, comments, attachments, templates, history, bulk, projects, sprints, discovery, translate, impact, users, articles, dashboard, monitoring, journey, deadlines, pulse, handoffs, time_report
 
 # Tools that modify data — blocked in read-only mode
 WRITE_TOOLS = frozenset({
@@ -38,7 +38,7 @@ WRITE_TOOLS = frozenset({
 
 # The "core" toolset (YOUTRACK_TOOLSET=core): the everyday issue-CRUD surface,
 # deliberately sized like the official YouTrack MCP server's ~23 predefined
-# tools. Exists for token economics — all 79 schemas cost ~21K context tokens
+# tools. Exists for token economics — all 81 schemas cost ~21K context tokens
 # per session on clients WITHOUT deferred tool loading (Cursor, n8n, …);
 # core cuts that ~4x. Analytics/reporting/bulk tools need "full". ADR-026.
 CORE_TOOLS = frozenset({
@@ -62,7 +62,7 @@ def _registered_tools(mcp) -> dict:
 
     FastMCP has no public API to enumerate/mutate registered tools after the
     fact, so we reach into `_tool_manager._tools` — a version-coupled hack
-    (pin: mcp>=1.0,<1.26 in pyproject). Keeping every reach-in behind this
+    (pin: mcp>=1.28.1,<2.0 in pyproject). Keeping every reach-in behind this
     accessor means an SDK layout change breaks exactly one function, and the
     hasattr guards degrade to a no-op ({}), never a crash.
     """
@@ -72,7 +72,7 @@ def _registered_tools(mcp) -> dict:
 
 def register_all(mcp, resolver: InstanceResolver, config: YouTrackConfig | None = None):
     # Collect all tools first, then filter
-    modules = [issues, comments, attachments, templates, history, bulk, projects, sprints, discovery, translate, impact, users, articles, dashboard, monitoring, journey, deadlines, pulse, handoffs]
+    modules = [issues, comments, attachments, templates, history, bulk, projects, sprints, discovery, translate, impact, users, articles, dashboard, monitoring, journey, deadlines, pulse, handoffs, time_report]
     for module in modules:
         module.register(mcp, resolver)
 

--- a/src/yt_mcp/tools/time_report.py
+++ b/src/yt_mcp/tools/time_report.py
@@ -1,0 +1,190 @@
+"""Time reports aggregated from work items.
+
+Both tools read the top-level `/api/workItems` endpoint — one paged request
+chain for the whole date range, no per-issue N+1 — and attribute time to the
+work-item AUTHOR (whoever logged it), filtered by work-item DATE (what the
+work was logged for), not issue `updated`. Contracts validated against a
+live instance (ADR-032): the endpoint returns a bare list of IssueWorkItem
+(`duration.minutes`, `author(login,name)`, `issue(idReadable)`, epoch-ms
+`date`); `startDate`/`endDate` accept `YYYY-MM-DD`; `author` accepts a login
+or user id and 404s (clean ValueError via the client) on unknown users.
+"""
+
+import calendar
+import re
+from datetime import datetime, timezone
+
+from yt_mcp.formatters import compact_lines, escape_query_value
+from yt_mcp.resolver import InstanceResolver
+
+_PAGE_SIZE = 500
+_MAX_ITEMS = 5000  # hard cap; reports say so when they hit it
+_DATE_RE = re.compile(r"^\d{4}-\d{2}-\d{2}$")
+_WORK_ITEM_FIELDS = "id,date,duration(minutes),author(login,name),issue(idReadable)"
+
+
+def _fmt_minutes(minutes: int) -> str:
+    if minutes >= 60:
+        return f"{minutes // 60}h {minutes % 60}m" if minutes % 60 else f"{minutes // 60}h"
+    return f"{minutes}m"
+
+
+async def _fetch_work_items(client, params: dict) -> tuple[list, bool]:
+    """Page through /api/workItems; returns (items, truncated)."""
+    items: list = []
+    skip = 0
+    while True:
+        page = await client.get(
+            "/api/workItems",
+            params={**params, "$top": _PAGE_SIZE, "$skip": skip},
+        )
+        items.extend(page)
+        if len(page) < _PAGE_SIZE:
+            return items, False
+        if len(items) >= _MAX_ITEMS:
+            return items, True
+        skip += _PAGE_SIZE
+
+
+def register(mcp, resolver: InstanceResolver):
+    """Register time reporting tools."""
+
+    @mcp.tool()
+    async def monthly_time_report_by_user(
+        instance: str = "",
+        projects: str = "",
+        year: int = 0,
+        month: int = 0,
+    ) -> str:
+        """Monthly time report aggregated by the user who logged the time.
+
+        Sums work-item durations for the calendar month, grouped by work-item
+        author — not issue assignee, so time on shared issues is credited to
+        whoever actually logged it.
+
+        Args:
+            instance: YouTrack instance name/URL (auto-detected if blank)
+            projects: Comma-separated project keys (all projects if blank)
+            year: Report year (default: current UTC year)
+            month: Report month 1-12 (default: current UTC month)
+        """
+        now = datetime.now(timezone.utc)
+        year = year or now.year
+        month = month or now.month
+        if not 1 <= month <= 12:
+            raise ValueError(f"month must be 1-12, got {month}")
+
+        days = calendar.monthrange(year, month)[1]
+        params = {
+            "fields": _WORK_ITEM_FIELDS,
+            "startDate": f"{year}-{month:02d}-01",
+            "endDate": f"{year}-{month:02d}-{days:02d}",
+        }
+        if projects:
+            keys = [escape_query_value(p.strip()) for p in projects.split(",") if p.strip()]
+            # Comma-list, not OR-joined clauses: YT 400s on
+            # `project: A OR project: B` (see rewrite_or_clauses, ADR-020).
+            params["query"] = f"project: {', '.join(keys)}"
+
+        client = resolver.resolve(instance)
+        items, truncated = await _fetch_work_items(client, params)
+        if not items:
+            return f"No work items logged in {year}-{month:02d}."
+
+        stats: dict[str, dict] = {}
+        for item in items:
+            author = item.get("author") or {}
+            name = author.get("name") or author.get("login") or "?"
+            entry = stats.setdefault(name, {"minutes": 0, "issues": set(), "entries": 0})
+            entry["minutes"] += (item.get("duration") or {}).get("minutes") or 0
+            entry["entries"] += 1
+            issue_id = (item.get("issue") or {}).get("idReadable")
+            if issue_id:
+                entry["issues"].add(issue_id)
+
+        scope = f" — projects: {projects}" if projects else ""
+        lines = [f"## Time report {year}-{month:02d}{scope}", ""]
+        total = 0
+        for name, s in sorted(stats.items(), key=lambda kv: kv[1]["minutes"], reverse=True):
+            total += s["minutes"]
+            lines.append(
+                f"- **{name}**: {_fmt_minutes(s['minutes'])} "
+                f"({len(s['issues'])} issues, {s['entries']} entries)"
+            )
+        lines.append("")
+        lines.append(
+            f"**Total:** {_fmt_minutes(total)} by {len(stats)} user(s), "
+            f"{len(items)} work item(s)"
+        )
+        if truncated:
+            lines.append(
+                f"⚠️ Truncated at {_MAX_ITEMS} work items — filter by `projects` for exact totals."
+            )
+        return compact_lines(lines)
+
+    @mcp.tool()
+    async def user_time_summary(
+        user: str,
+        instance: str = "",
+        since: str = "",
+        until: str = "",
+        top_issues: int = 10,
+    ) -> str:
+        """Time summary for one user: total logged plus per-issue breakdown.
+
+        Matches by work-item author and work-item date. Unknown users surface
+        YouTrack's own error message.
+
+        Args:
+            user: YouTrack login (or user id) — required
+            instance: YouTrack instance name/URL (auto-detected if blank)
+            since: Start date YYYY-MM-DD (optional)
+            until: End date YYYY-MM-DD (optional)
+            top_issues: How many top issues to list (default: 10)
+        """
+        if not user:
+            raise ValueError("user is required")
+        for label, value in (("since", since), ("until", until)):
+            if value and not _DATE_RE.match(value):
+                raise ValueError(f"{label} must be YYYY-MM-DD, got {value!r}")
+
+        params = {"fields": _WORK_ITEM_FIELDS, "author": user}
+        if since:
+            params["startDate"] = since
+        if until:
+            params["endDate"] = until
+
+        client = resolver.resolve(instance)
+        items, truncated = await _fetch_work_items(client, params)
+        period = f"{since or '…'} → {until or 'now'}"
+        if not items:
+            scope = f" in {period}" if (since or until) else ""
+            return f"No work items logged by {user}{scope}."
+
+        per_issue: dict[str, int] = {}
+        total = 0
+        for item in items:
+            minutes = (item.get("duration") or {}).get("minutes") or 0
+            total += minutes
+            issue_id = (item.get("issue") or {}).get("idReadable") or "?"
+            per_issue[issue_id] = per_issue.get(issue_id, 0) + minutes
+
+        display = (items[0].get("author") or {}).get("name") or user
+        lines = [f"## Time summary — {display}"]
+        if since or until:
+            lines.append(f"Period: {period}")
+        lines.append(
+            f"**Total:** {_fmt_minutes(total)} across {len(per_issue)} issue(s), "
+            f"{len(items)} work item(s)"
+        )
+        if top_issues > 0:
+            lines.append("")
+            lines.append("Top issues:")
+            ranked = sorted(per_issue.items(), key=lambda kv: kv[1], reverse=True)
+            for issue_id, minutes in ranked[:top_issues]:
+                lines.append(f"- {issue_id}: {_fmt_minutes(minutes)}")
+        if truncated:
+            lines.append(
+                f"⚠️ Truncated at {_MAX_ITEMS} work items — narrow the date range for exact totals."
+            )
+        return compact_lines(lines)

--- a/tests/test_registration.py
+++ b/tests/test_registration.py
@@ -45,7 +45,7 @@ class TestToolRegistration:
         register_all(mcp, resolver, config)
 
         tools = _get_tool_names(mcp)
-        assert len(tools) == 79, f"Expected 79 tools, got {len(tools)}: {sorted(tools)}"
+        assert len(tools) == 81, f"Expected 81 tools, got {len(tools)}: {sorted(tools)}"
 
     def test_expected_tools_present(self):
         mcp = FastMCP("test")
@@ -78,6 +78,7 @@ class TestToolRegistration:
             "audit_deadline_changes", "deadline_scorecard", "suggest_managers",
             "get_team_pulse", "get_multi_team_pulse", "get_stuck_handoffs",
             "get_impact_map", "get_deadline_impact",
+            "monthly_time_report_by_user", "user_time_summary",
             "get_current_user", "get_instance_url", "search_users",
             "search_articles", "get_article", "create_article",
             "update_article", "delete_article",
@@ -174,7 +175,7 @@ class TestToolRegistration:
         register_all(mcp, resolver, config=None)
 
         tools = _get_tool_names(mcp)
-        assert len(tools) == 79
+        assert len(tools) == 81
 
 
 class TestCoreToolset:
@@ -208,4 +209,4 @@ class TestCoreToolset:
         assert "create_issue" not in names
 
     def test_full_unchanged(self):
-        assert len(self._register(toolset="full")) == 79
+        assert len(self._register(toolset="full")) == 81

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -133,7 +133,7 @@ class TestServerStartup:
         assert tools_resp is not None, f"No tools/list response found in: {responses}"
         tools = tools_resp["result"]["tools"]
         tool_names = {t["name"] for t in tools}
-        assert len(tool_names) == 79, f"Expected 79 tools, got {len(tool_names)}"
+        assert len(tool_names) == 81, f"Expected 81 tools, got {len(tool_names)}"
         # Spot check a few
         assert "search_issues" in tool_names
         assert "get_article" in tool_names
@@ -204,4 +204,4 @@ class TestServerStartup:
         from yt_mcp.tools import _registered_tools
         bundle = build_server()
         assert bundle.oauth_provider is None
-        assert len(_registered_tools(bundle.mcp)) == 79
+        assert len(_registered_tools(bundle.mcp)) == 81

--- a/tests/test_time_report.py
+++ b/tests/test_time_report.py
@@ -1,0 +1,150 @@
+"""Tests for time_report tools.
+
+Mocks mirror the REAL /api/workItems contract (validated live, ADR-032):
+a bare JSON list of IssueWorkItem objects with duration.minutes,
+author(login,name), issue(idReadable), epoch-ms date — NOT a dict wrapper.
+"""
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from mcp.server.fastmcp import FastMCP
+
+from yt_mcp.tools import time_report
+
+
+def _item(minutes, author_name="Alice", author_login="alice", issue="PROJ-1"):
+    return {
+        "id": "111-1",
+        "date": 1780272000000,
+        "duration": {"minutes": minutes, "$type": "DurationValue"},
+        "author": {"login": author_login, "name": author_name, "$type": "User"},
+        "issue": {"idReadable": issue, "$type": "Issue"},
+        "$type": "IssueWorkItem",
+    }
+
+
+def _setup(response):
+    client = MagicMock()
+    client.get = AsyncMock(return_value=response)
+    resolver = MagicMock()
+    resolver.resolve = MagicMock(return_value=client)
+    mcp = FastMCP("test")
+    time_report.register(mcp, resolver)
+    tools = mcp._tool_manager._tools
+    return client, tools
+
+
+class TestMonthlyReport:
+    async def test_aggregates_by_author_not_assignee(self):
+        client, tools = _setup([
+            _item(120, "Alice", "alice", "PROJ-1"),
+            _item(60, "Bob", "bob", "PROJ-1"),   # same issue, different logger
+            _item(30, "Alice", "alice", "PROJ-2"),
+        ])
+        out = await tools["monthly_time_report_by_user"].fn(year=2026, month=6)
+        assert "Alice" in out and "Bob" in out
+        assert "2h 30m" in out          # Alice: 120 + 30
+        assert "1h" in out              # Bob: 60
+        assert "3h 30m" in out          # total: 210m
+
+    async def test_totals_and_issue_counts(self):
+        client, tools = _setup([
+            _item(90, "Alice", "alice", "PROJ-1"),
+            _item(30, "Alice", "alice", "PROJ-2"),
+        ])
+        out = await tools["monthly_time_report_by_user"].fn(year=2026, month=6)
+        assert "2 issues" in out
+        assert "2 entries" in out
+        assert "**Total:** 2h by 1 user(s), 2 work item(s)" in out
+
+    async def test_sends_month_date_range(self):
+        client, tools = _setup([])
+        await tools["monthly_time_report_by_user"].fn(year=2026, month=2)
+        params = client.get.call_args.kwargs["params"]
+        assert params["startDate"] == "2026-02-01"
+        assert params["endDate"] == "2026-02-28"
+        assert "duration(minutes)" in params["fields"]
+
+    async def test_defaults_to_current_month(self):
+        from datetime import datetime, timezone
+        client, tools = _setup([])
+        await tools["monthly_time_report_by_user"].fn()
+        now = datetime.now(timezone.utc)
+        params = client.get.call_args.kwargs["params"]
+        assert params["startDate"] == f"{now.year}-{now.month:02d}-01"
+
+    async def test_projects_filter_uses_comma_list_not_or(self):
+        client, tools = _setup([])
+        await tools["monthly_time_report_by_user"].fn(
+            projects="PROJ, OPS", year=2026, month=6
+        )
+        query = client.get.call_args.kwargs["params"]["query"]
+        assert query == "project: PROJ, OPS"   # YT 400s on OR-joined clauses
+        assert " OR " not in query
+
+    async def test_invalid_month_rejected(self):
+        client, tools = _setup([])
+        with pytest.raises(ValueError, match="month must be 1-12"):
+            await tools["monthly_time_report_by_user"].fn(year=2026, month=13)
+
+    async def test_empty_month(self):
+        client, tools = _setup([])
+        out = await tools["monthly_time_report_by_user"].fn(year=2026, month=6)
+        assert "No work items logged in 2026-06" in out
+
+    async def test_paginates_until_short_page(self, monkeypatch):
+        monkeypatch.setattr(time_report, "_PAGE_SIZE", 2)
+        pages = [
+            [_item(10), _item(20)],
+            [_item(30), _item(40)],
+            [_item(50)],
+        ]
+        client, tools = _setup(None)
+        client.get = AsyncMock(side_effect=pages)
+        out = await tools["monthly_time_report_by_user"].fn(year=2026, month=6)
+        assert client.get.call_count == 3
+        skips = [c.kwargs["params"]["$skip"] for c in client.get.call_args_list]
+        assert skips == [0, 2, 4]
+        assert "5 work item(s)" in out
+        assert "Truncated" not in out
+
+    async def test_truncation_is_reported(self, monkeypatch):
+        monkeypatch.setattr(time_report, "_PAGE_SIZE", 2)
+        monkeypatch.setattr(time_report, "_MAX_ITEMS", 4)
+        client, tools = _setup(None)
+        client.get = AsyncMock(return_value=[_item(10), _item(20)])  # always-full pages
+        out = await tools["monthly_time_report_by_user"].fn(year=2026, month=6)
+        assert "Truncated at 4 work items" in out
+        assert client.get.call_count == 2  # stopped at the cap, no runaway
+
+
+class TestUserTimeSummary:
+    async def test_requires_user(self):
+        client, tools = _setup([])
+        with pytest.raises(ValueError, match="user is required"):
+            await tools["user_time_summary"].fn(user="")
+
+    async def test_date_format_validated(self):
+        client, tools = _setup([])
+        with pytest.raises(ValueError, match="since must be YYYY-MM-DD"):
+            await tools["user_time_summary"].fn(user="alice", since="June 2026")
+
+    async def test_totals_and_top_issues(self):
+        client, tools = _setup([
+            _item(120, "Alice", "alice", "PROJ-1"),
+            _item(45, "Alice", "alice", "PROJ-2"),
+            _item(15, "Alice", "alice", "PROJ-1"),
+        ])
+        out = await tools["user_time_summary"].fn(user="alice", since="2026-06-01")
+        params = client.get.call_args.kwargs["params"]
+        assert params["author"] == "alice"
+        assert params["startDate"] == "2026-06-01"
+        assert "**Total:** 3h across 2 issue(s), 3 work item(s)" in out
+        # per-issue breakdown, largest first
+        assert out.index("PROJ-1: 2h 15m") < out.index("PROJ-2: 45m")
+
+    async def test_empty_result(self):
+        client, tools = _setup([])
+        out = await tools["user_time_summary"].fn(user="alice", since="2026-06-01")
+        assert "No work items logged by alice" in out


### PR DESCRIPTION
Implements the monthly time-report feature proposed in #3, rebuilt on API contracts validated against a live YouTrack instance before any code was written. Credit to @islamumarov for the feature idea and tool naming.

## Why a reimplementation

The #3 approach aggregated time out of `/api/issues` custom fields; review found the query is rejected by YouTrack (400), the response shape was wrong (bare list vs `{"issue": ...}`), and spent time was parsed from an entity id — totals were always 0. Details with reproductions: https://github.com/velesnitski/yt-mcp/pull/3#pullrequestreview-4723951444.

## Design (ADR-032)

- **Top-level `GET /api/workItems`** — one paged request chain per report, no per-issue N+1. Live-validated: bare list of `IssueWorkItem` with `duration.minutes`, `author(login,name)`, `issue(idReadable)`; `startDate`/`endDate` accept `YYYY-MM-DD`.
- **Attribution to work-item author** (whoever logged the time), not issue assignee — shared issues report correctly.
- **Filtered by work-item date**, not issue `updated` — June work on a July-updated issue lands in June.
- Multi-project filter uses the comma-list idiom (`project: A, B`); OR-joined clauses 400 (same trap as ADR-020).
- `$top`/`$skip` pagination (500/page) with a 5000-item cap that is **reported in the output** when hit, never silent.
- `year`/`month` default to the current UTC month; date params validated up front; unknown users surface YouTrack's own error via the client's clean `ValueError` mapping.

## Tools

- `monthly_time_report_by_user(instance, projects, year, month)` — per-user minutes, distinct-issue and entry counts, sorted by time, with total.
- `user_time_summary(user, instance, since, until, top_issues)` — one user's total + top-issues breakdown.

Both read-only; registered in the `full` toolset only (not `CORE_TOOLS`, per ADR-026's analytics split).

## Verification

- 13 new tests whose mocks mirror the **validated** endpoint shapes — including pagination (`$skip` progression) and cap-truncation; 797 total pass.
- 79 → 81 tools, 19 → 20 modules (CLAUDE.md + registration tests updated).
- Also fixes the stale SDK-pin comment in `tools/__init__.py` (stale since the ADR-030 mcp bump).

Supersedes #3.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
